### PR TITLE
avoid double initialization of smart listing controls

### DIFF
--- a/app/assets/javascripts/smart_listing.coffee.erb
+++ b/app/assets/javascripts/smart_listing.coffee.erb
@@ -343,6 +343,10 @@ $.fn.smart_listing_controls = () ->
     smart_listing.reload()
 
   $(this).each () ->
+    # avoid double initialization
+    return if $(this).data('<%= SmartListing.config.data_attributes(:controls) %>')
+    $(this).data('<%= SmartListing.config.data_attributes(:controls) %>', true)
+
     controls = $(this)
     smart_listing = $("##{controls.data('<%= SmartListing.config.data_attributes(:main) %>')}")
     reset = controls.find(".<%= SmartListing.config.classes(:controls_reset) %>")

--- a/lib/smart_listing/config.rb
+++ b/lib/smart_listing/config.rb
@@ -68,6 +68,7 @@ module SmartListing
         },
         :data_attributes => {
           :main => "smart-listing",
+          :controls => "smart-listing-controls",
           :confirmation => "confirmation",
           :id => "id",
           :href => "href",


### PR DESCRIPTION
Calling `smart_listing_controls` several times should initialize the plugin only once (as done in `smart_listing`, too).
