### PR TITLE
Add Turbolinks support

### DIFF
--- a/app/assets/javascripts/smart_listing.coffee.erb
+++ b/app/assets/javascripts/smart_listing.coffee.erb
@@ -383,6 +383,9 @@ $.fn.smart_listing_controls.filter = (filter) ->
       field.trigger('keydown')
     return false
 
-$ ->
+ready ->
   $('.<%= SmartListing.config.classes(:main) %>').smart_listing()
   $('.<%= SmartListing.config.classes(:controls) %>').smart_listing_controls()
+
+$(document).ready ready
+$(document).on "page:load", ready


### PR DESCRIPTION
If the Turbolinks gem is used, jQuerys ready() method won't be triggered on page changes that are initiated by Turbolinks. By adding the correspondig Turbolinks page:load hook, smart_listing will work even Turbolinks is used. This hopefully fixes #18.
