### PR TITLE
Refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ smart_listing_render(:users)
 - unless smart_listing.empty?
   %table
     %thead
-      %tr 
+      %tr
         %th User name
         %th Email
     %tbody
@@ -82,7 +82,7 @@ smart_listing_render(:users)
           %td= user.name
           %td= user.email
 
-  = smart_listing.paginate 
+  = smart_listing.paginate
 - else
   %p.warning No records!
 ```
@@ -112,7 +112,7 @@ SmartListing supports two modes of sorting: implicit and explicit. Implicit mode
 - unless smart_listing.empty?
   %table
     %thead
-      %tr 
+      %tr
         %th= smart_listing.sortable "User name", :name
         %th= smart_listing.sortable "Email", :email
     %tbody
@@ -121,12 +121,12 @@ SmartListing supports two modes of sorting: implicit and explicit. Implicit mode
           %td= user.name
           %td= user.email
 
-  = smart_listing.paginate 
+  = smart_listing.paginate
 - else
   %p.warning No records!
 ```
 
-In this case `:name` and `:email` are sorting column names. `Builder#sortable` renders special link containing column name and sort order (either `asc`, `desc`, or empty value). 
+In this case `:name` and `:email` are sorting column names. `Builder#sortable` renders special link containing column name and sort order (either `asc`, `desc`, or empty value).
 
 You can also specify default sort order in the controller:
 
@@ -136,7 +136,7 @@ You can also specify default sort order in the controller:
 
 Implicit mode is convenient with simple data sets. In case you want to sort by joined column names, we advise you to use explicit sorting:
 ```ruby
-@users = smart_listing_create :users, User.active.joins(:stats), partial: "users/listing", 
+@users = smart_listing_create :users, User.active.joins(:stats), partial: "users/listing",
                               sort_attributes: [[:last_signin, "stats.last_signin_at"]],
                               default_sort: {last_signin: "desc"}
 ```
@@ -153,7 +153,7 @@ In order to allow managing and editing list items, we need to reorganize our vie
 - unless smart_listing.empty?
   %table
     %thead
-      %tr 
+      %tr
         %th= smart_listing.sortable "User name", "name"
         %th= smart_listing.sortable "Email", "email"
         %th
@@ -161,9 +161,9 @@ In order to allow managing and editing list items, we need to reorganize our vie
       - smart_listing.collection.each do |user|
         %tr.editable{data: {id: user.id}}
           = smart_listing.render partial: 'users/user', locals: {user: user}
-      = smart_listing.item_new colspan: 3, link: new_user_path 
+      = smart_listing.item_new colspan: 3, link: new_user_path
 
-  = smart_listing.paginate 
+  = smart_listing.paginate
 - else
   %p.warning No records!
 ```
@@ -174,7 +174,7 @@ In order to allow managing and editing list items, we need to reorganize our vie
 <%= smart_listing_item :users, :new, @new_user, "users/form" %>
 ```
 
-Note that `new` action does not need to create SmartListing (via `smart_listing_create`). It just initializes `@new_user` and renders JS view. 
+Note that `new` action does not need to create SmartListing (via `smart_listing_create`). It just initializes `@new_user` and renders JS view.
 
 New partial for user (`users/user`) may look like this:
 ```haml
@@ -204,10 +204,10 @@ Partial name supplied to `smart_listing_item` (`users/form`) references `@user` 
 
   = form_for object, url: object.new_record? ? users_path : user_path(object), remote: true do |f|
     %p
-      Name: 
+      Name:
       = f.text_field :name
     %p
-      Email: 
+      Email:
       = f.text_field :email
     %p= f.submit "Save"
 ```

--- a/app/assets/javascripts/smart_listing.coffee.erb
+++ b/app/assets/javascripts/smart_listing.coffee.erb
@@ -77,7 +77,7 @@ class SmartListing
 
   fadeLoaded: =>
     $.fn.smart_listing.onLoaded(@content, @loading)
-  
+
   itemCount: =>
     parseInt(@container.data('<%= SmartListing.config.data_attributes(:item_count) %>'))
 
@@ -98,7 +98,7 @@ class SmartListing
       editable.html(editable.data('<%= SmartListing.config.data_attributes(:inline_edit_backup) %>'))
       editable.removeClass('<%= SmartListing.config.classes(:inline_editing) %>')
       editable.removeData('<%= SmartListing.config.data_attributes(:inline_edit_backup) %>')
-  
+
   # Callback called when record is added/deleted using ajax request
   refresh: () =>
     header = @content.find('<%= SmartListing.config.selectors(:head) %>')
@@ -132,11 +132,11 @@ class SmartListing
         $(status).find('.<%= SmartListing.config.classes(:limit_alert) %>').show()
       else
         $(status).find('.<%= SmartListing.config.classes(:limit_alert) %>').hide()
-  
+
   # Trigger AJAX request to reload the list
   reload: () =>
     $.rails.handleRemote(@container)
-  
+
   params: (value) =>
     if value
       @container.data('<%= SmartListing.config.data_attributes(:params) %>', value)
@@ -222,7 +222,7 @@ class SmartListing
       @container.trigger("smart_listing:update:fail", editable)
 
     @fadeLoaded()
-  
+
   destroy: (id, destroyed) =>
     # No need to do anything here, already handled by ajax:success handler
 
@@ -231,7 +231,7 @@ class SmartListing
     editable.remove()
 
     @container.trigger("smart_listing:remove", editable)
-  
+
   update_list: (content, data) =>
     @container.data("<%= SmartListing.config.data_attributes(:params) %>", $.extend(@container.data("<%= SmartListing.config.data_attributes(:params) %>"), data["<%= SmartListing.config.data_attributes(:params) %>"]))
     @container.data("<%= SmartListing.config.data_attributes(:max_count) %>", data["<%= SmartListing.config.data_attributes(:max_count) %>"])
@@ -260,7 +260,7 @@ $.fn.smart_listing.observeField = (field, opts = {}) ->
      onEmpty: () ->
      onChange: () ->
    options = $.extend(options, opts)
- 
+
    keyChange = () ->
      if field.val().length > 0
        options.onFilled()
@@ -270,15 +270,15 @@ $.fn.smart_listing.observeField = (field, opts = {}) ->
      if field.val() == last_value && field.val().length != 0
        return
      lastValue = field.val()
- 
+
      options.onChange()
- 
+
    field.data('<%= SmartListing.config.data_attributes(:observed) %>', true)
- 
+
    field.bind 'keydown', (e) ->
      if(key_timeout)
        clearTimeout(key_timeout)
- 
+
      key_timeout = setTimeout(->
        keyChange()
      , 400)

--- a/app/helpers/smart_listing/helper.rb
+++ b/app/helpers/smart_listing/helper.rb
@@ -307,15 +307,15 @@ module SmartListing
     end
 
     # Renders single item (i.e for create, update actions)
-    def smart_listing_item name, item_action, object = nil, partial = nil, options = {}
-      name = name.to_sym
-      type = object.class.name.downcase.to_sym if object
-      id = options[:id] || object.try(:id)
-      valid = options[:valid] if options.has_key?(:valid)
-      object_key = options.delete(:object_key) || :object
-      new = options.delete(:new)
+    def smart_listing_item item_action, options = {}
+      object = options[:object]
 
-      render(:partial => "smart_listing/item/#{item_action.to_s}", :locals => {:name => name, :id => id, :valid => valid, :object_key => object_key, :object => object, :part => partial, :new => new})
+      options[:name]        ||= object.class.name.underscore.pluralize.to_sym
+      options[:type]        ||= object.class.name.downcase.to_sym if object
+      options[:id]          ||= object.try(:id)
+      options[:object_key]  ||= :object
+
+      render(:partial => "smart_listing/item/#{item_action.to_s}", :locals => options)
     end
   end
 end

--- a/app/helpers/smart_listing/helper.rb
+++ b/app/helpers/smart_listing/helper.rb
@@ -55,7 +55,7 @@ module SmartListing
         per_page_sizes.push(0) if @smart_listing.unlimited_per_page?
 
         locals = {
-          :container_classes => container_classes, 
+          :container_classes => container_classes,
           :per_page_sizes => per_page_sizes,
         }
 
@@ -68,7 +68,7 @@ module SmartListing
         end
 
         locals = {
-          :page => page, 
+          :page => page,
           :url => url,
         }
 
@@ -77,7 +77,7 @@ module SmartListing
 
       def sortable title, attribute, options = {}
         dirs = options[:sort_dirs] || @smart_listing.sort_dirs || [nil, "asc", "desc"]
-        
+
         next_index = dirs.index(@smart_listing.sort_order(attribute)).nil? ? 0 : (dirs.index(@smart_listing.sort_order(attribute)) + 1) % dirs.length
 
         sort_params = {
@@ -233,7 +233,7 @@ module SmartListing
           next unless action.is_a?(Hash)
 
           locals = {
-            :action_if => action.has_key?(:if) ? action[:if] : true, 
+            :action_if => action.has_key?(:if) ? action[:if] : true,
             :url => action.delete(:url),
             :icon => action.delete(:icon),
             :title => action.delete(:title),
@@ -295,9 +295,9 @@ module SmartListing
 
       builder = Builder.new(name, smart_listing, self, {}, nil)
       render(:partial => 'smart_listing/update_list', :locals => {
-        :name => smart_listing.name, 
-        :part => smart_listing.partial, 
-        :smart_listing => builder, 
+        :name => smart_listing.name,
+        :part => smart_listing.partial,
+        :smart_listing => builder,
         :smart_listing_data => {
           SmartListing.config.data_attributes(:params) => smart_listing.all_params,
           SmartListing.config.data_attributes(:max_count) => smart_listing.max_count,

--- a/app/views/smart_listing/_action_custom.html.erb
+++ b/app/views/smart_listing/_action_custom.html.erb
@@ -1,4 +1,4 @@
-<%# 
+<%#
   Custom action.
 
   Available local variables:

--- a/app/views/smart_listing/_action_delete.html.erb
+++ b/app/views/smart_listing/_action_delete.html.erb
@@ -1,4 +1,4 @@
-<%# 
+<%#
   Delete action.
 
   Available local variables:

--- a/app/views/smart_listing/_action_edit.html.erb
+++ b/app/views/smart_listing/_action_edit.html.erb
@@ -1,4 +1,4 @@
-<%# 
+<%#
   Edit action.
 
   Available local variables:

--- a/app/views/smart_listing/_action_show.html.erb
+++ b/app/views/smart_listing/_action_show.html.erb
@@ -1,4 +1,4 @@
-<%# 
+<%#
   Show action.
 
   Available local variables:

--- a/app/views/smart_listing/_item_new.html.erb
+++ b/app/views/smart_listing/_item_new.html.erb
@@ -1,10 +1,10 @@
-<%# 
+<%#
   New list item element (contains new item placeholder and add button).
 
   Available local variables:
     placeholder_classes:      classes for the main container
     new_item_action_classes:  new item action classes
-    colspan              
+    colspan
     no_items_classes:         no items container classes
     no_items_text:            no items text displayed inside container
     new_item_button_url:      argument to link_to (new item button)

--- a/app/views/smart_listing/_pagination_per_page_link.html.erb
+++ b/app/views/smart_listing/_pagination_per_page_link.html.erb
@@ -1,4 +1,4 @@
-<%# 
+<%#
   Pagination single per-page link.
 
   Available local variables:

--- a/app/views/smart_listing/_pagination_per_page_links.html.erb
+++ b/app/views/smart_listing/_pagination_per_page_links.html.erb
@@ -1,4 +1,4 @@
-<%# 
+<%#
   Pagination per-page links.
 
   Available local variables:

--- a/app/views/smart_listing/_sortable.html.erb
+++ b/app/views/smart_listing/_sortable.html.erb
@@ -1,4 +1,4 @@
-<%# 
+<%#
   Sortable attribute listing header.
 
   Available local variables:

--- a/lib/generators/smart_listing/install_generator.rb
+++ b/lib/generators/smart_listing/install_generator.rb
@@ -5,7 +5,7 @@ module SmartListing
 
       def self.banner #:nodoc:
         <<-BANNER.chomp
-rails g smart_listing:install 
+rails g smart_listing:install
 
     Copies initializer file
 BANNER

--- a/lib/generators/smart_listing/views_generator.rb
+++ b/lib/generators/smart_listing/views_generator.rb
@@ -5,7 +5,7 @@ module SmartListing
 
       def self.banner #:nodoc:
         <<-BANNER.chomp
-rails g smart_listing:views 
+rails g smart_listing:views
 
     Copies all smart listing partials templates to your application.
 BANNER

--- a/lib/smart_listing.rb
+++ b/lib/smart_listing.rb
@@ -37,7 +37,7 @@ module SmartListing
 
       if @options[:array]
         @collection = collection.to_a
-      else 
+      else
         @collection = collection
       end
     end
@@ -86,8 +86,8 @@ module SmartListing
               else
                 (yval <=> xval) || (yval && !xval ? 1 : -1)
               end
-            end 
-          end 
+            end
+          end
         end
         if @options[:paginate] && @per_page > 0
           @collection = ::Kaminari.paginate_array(@collection).page(@page).per(@per_page)

--- a/lib/smart_listing/config.rb
+++ b/lib/smart_listing/config.rb
@@ -98,7 +98,7 @@ module SmartListing
     def method_missing(sym, *args, &block)
       @options[sym] = *args
     end
-    
+
     def constants key, value = nil
       if value
         @options[:constants][key].merge!(value)

--- a/smart_listing.gemspec
+++ b/smart_listing.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.add_dependency "rails", ">=3.2"
 	s.add_dependency "coffee-rails"
 	s.add_dependency "kaminari", "~> 0.16.1"
-	
+
 	s.add_development_dependency "sqlite3"
 
 end


### PR DESCRIPTION
I have some refactoring to suggest. I have som point to clarify
- If you have specs, it can be very very useful. 
- Is it one of your goal be compatible with old rails versions? Why do you write `render(:partial => "...", :locals => "...")` instead of `render(partial: "..", "...")` and why do you use the old ruby synthax?

It think `app/views/smart_listing/item/_create.js.rb` can be simplified. It can be simpler and clearer than : 

```
<%= smart_listing_item :create, object: resource,
  partial: resource.valid? ? "item" : "form" %>
```
