### PR TITLE
Remove duplicate href key

### DIFF
--- a/lib/smart_listing/config.rb
+++ b/lib/smart_listing/config.rb
@@ -80,7 +80,6 @@ module SmartListing
           :inline_edit_backup => "smart-listing-edit-backup",
           :params => "params",
           :observed => "observed",
-          :href => "href",
           :autoshow => "autoshow",
           :popover => "slpopover",
         },


### PR DESCRIPTION
The data_attributes hash has two identical href keys. Therefore ruby will complain with a warning.