### PR TITLE
Added real_object parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ spec/dummy/db/*.sqlite3
 spec/dummy/log/*.log
 spec/dummy/tmp/
 tags
+
+*~
+*#

--- a/app/helpers/smart_listing/helper.rb
+++ b/app/helpers/smart_listing/helper.rb
@@ -266,10 +266,10 @@ module SmartListing
           case action_name
           when :show
             locals[:icon] ||= smart_listing_config.classes(:icon_show)
-						template = 'action_show'
+                        template = 'action_show'
           when :edit
             locals[:icon] ||= smart_listing_config.classes(:icon_edit)
-						template = 'action_edit'
+                        template = 'action_edit'
           when :destroy
             locals[:icon] ||= smart_listing_config.classes(:icon_trash)
             locals.merge!(
@@ -355,8 +355,9 @@ module SmartListing
       valid = options[:valid] if options.has_key?(:valid)
       object_key = options.delete(:object_key) || :object
       new = options.delete(:new)
+      real_object = options.delete(:real_object) || object
 
-      render(:partial => "smart_listing/item/#{item_action.to_s}", :locals => {:name => name, :id => id, :valid => valid, :object_key => object_key, :object => object, :part => partial, :new => new})
+      render(:partial => "smart_listing/item/#{item_action.to_s}", :locals => {:name => name, :id => id, :valid => valid, :object_key => object_key, :object => object, :part => partial, :new => new, :real_object => real_object})
     end
   end
 end

--- a/app/views/smart_listing/item/_create.js.erb
+++ b/app/views/smart_listing/item/_create.js.erb
@@ -1,3 +1,3 @@
 var smart_listing = $('#<%= name %>').smart_listing();
 smart_listing.setAutoshow(false);
-smart_listing.create(<%= id || 0 %>, <%= object.persisted? %>, "<%= escape_javascript(render(:partial => part, :locals => {object_key => object})) %>");
+smart_listing.create(<%= id || 0 %>, <%= real_object.persisted? %>, "<%= escape_javascript(render(:partial => part, :locals => {object_key => object})) %>");

--- a/app/views/smart_listing/item/_create_continue.js.erb
+++ b/app/views/smart_listing/item/_create_continue.js.erb
@@ -1,6 +1,6 @@
 var smart_listing = $('#<%= name %>').smart_listing();
 smart_listing.setAutoshow(true);
-smart_listing.create(<%= id || 0 %>, <%= object.persisted? %>, "<%= escape_javascript(render(:partial => part, :locals => {object_key => object})) %>");
-<% if object.persisted? %>
+smart_listing.create(<%= id || 0 %>, <%= real_object.persisted? %>, "<%= escape_javascript(render(:partial => part, :locals => {object_key => object})) %>");
+<% if real_object.persisted? %>
   smart_listing.new_item("<%= escape_javascript(render(:partial => new.last, :locals => {object_key => new.first})) %>");
 <% end %>

--- a/app/views/smart_listing/item/_destroy.js.erb
+++ b/app/views/smart_listing/item/_destroy.js.erb
@@ -1,2 +1,2 @@
 var smart_listing = $('#<%= name.to_s %>').smart_listing();
-smart_listing.destroy(<%= id %>, <%= object.destroyed? %>);
+smart_listing.destroy(<%= id %>, <%= real_object.destroyed? %>);

--- a/app/views/smart_listing/item/_update.js.erb
+++ b/app/views/smart_listing/item/_update.js.erb
@@ -1,2 +1,2 @@
 var smart_listing = $('#<%= name %>').smart_listing();
-smart_listing.update(<%= id %>, <%= valid.nil? ? object.valid? : valid %>, "<%= escape_javascript(render(:partial => part, :locals => {object_key => object})) %>");
+smart_listing.update(<%= id %>, <%= valid.nil? ? real_object.valid? : valid %>, "<%= escape_javascript(render(:partial => part, :locals => {object_key => object})) %>");


### PR DESCRIPTION
The real_object parameter in SmartListing JS view functions (smart_listing_item) enables user to pass to partial (eg. form) as object something other than ActiveRecord object (eg. a Hash) and additionally pass the real ActiveRecord object for validity and successful action checks done by SmartListing in its internal JS views. Consider adding it, because it proves very useful for more complex projects and needs.
