### PR TITLE
Add Turbolinks compatibility and Loading Indicator

### DIFF
--- a/app/assets/javascripts/smart_listing.coffee.erb
+++ b/app/assets/javascripts/smart_listing.coffee.erb
@@ -349,12 +349,16 @@ $.fn.smart_listing.confirm = (elem, msg) ->
     true
 
 $.fn.smart_listing.onLoading = (content, loader, loading_indicator) ->
-  loader.addClass('active')
+  content.stop(true).fadeTo(500, 0.2)
+  loader.show()
   loading_indicator.addClass('active')
+  loader.stop(true).fadeTo(500, 1)
 
 $.fn.smart_listing.onLoaded = (content, loader, loading_indicator) ->
-  loader.removeClass('active')
-  loading_indicator.removeClass('active')
+  content.stop(true).fadeTo(500, 1)
+  loader.stop(true).fadeTo 500, 0, () =>
+    loader.hide()
+    loading_indicator.removeClass('active')
 
 $.fn.smart_listing_controls = () ->
   reload = (controls) ->

--- a/app/assets/javascripts/smart_listing.coffee.erb
+++ b/app/assets/javascripts/smart_listing.coffee.erb
@@ -28,7 +28,7 @@ class window.SmartListing
     @container = e
     @name = @container.attr("id")
     @loading = @container.find(SmartListing.config.class_name("loading"))
-    @loading_indicator = @container.find(SmartListing.config.class_name("loading_indicator"))
+    @loading_indicator = $("loading_indicator")
     @content = @container.find(SmartListing.config.class_name("content"))
     @status = $("#{SmartListing.config.class_name("status")} [data-#{SmartListing.config.data_attribute("main")}='#{@name}']")
     @confirmed = null

--- a/app/assets/javascripts/smart_listing.coffee.erb
+++ b/app/assets/javascripts/smart_listing.coffee.erb
@@ -299,8 +299,8 @@ $.fn.smart_listing.observeField = (field, opts = {}) ->
    field.data(SmartListing.config.data_attribute("observed"), true)
  
    field.bind "keydown", (e) ->
-    console.log(e)
-    console.log(field)
+     console.log(e)
+     console.log(field)
      if(key_timeout)
        clearTimeout(key_timeout)
  

--- a/app/assets/javascripts/smart_listing.coffee.erb
+++ b/app/assets/javascripts/smart_listing.coffee.erb
@@ -95,11 +95,11 @@ class window.SmartListing
       })
 
   fadeLoading: =>
-    $.fn.smart_listing.onLoading(@content, @loading, @loading_indicator)
+    $.fn.smart_listing.onLoading(@loading, @loading_indicator)
 
   fadeLoaded: =>
-    $.fn.smart_listing.onLoaded(@content, @loading, @loading_indicator)
-  
+    $.fn.smart_listing.onLoaded(@loading, @loading_indicator)
+
   itemCount: =>
     parseInt(@container.data(SmartListing.config.data_attribute("item_count")))
 
@@ -120,7 +120,7 @@ class window.SmartListing
       editable.html(editable.data(SmartListing.config.data_attribute("inline_edit_backup")))
       editable.removeClass(SmartListing.config.class("inline_editing"))
       editable.removeData(SmartListing.config.data_attribute("inline_edit_backup"))
-  
+
   # Callback called when record is added/deleted using ajax request
   refresh: () =>
     header = @content.find(SmartListing.config.selector("head"))
@@ -154,11 +154,11 @@ class window.SmartListing
         $(status).find(SmartListing.config.class_name("limit_alert")).show()
       else
         $(status).find(SmartListing.config.class_name("limit_alert")).hide()
-  
+
   # Trigger AJAX request to reload the list
   reload: () =>
     $.rails.handleRemote(@container)
-  
+
   params: (value) =>
     if value
       @container.data(SmartListing.config.data_attribute("params"), value)
@@ -244,7 +244,7 @@ class window.SmartListing
       @container.trigger("smart_listing:update:fail", editable)
 
     @fadeLoaded()
-  
+
   destroy: (id, destroyed) =>
     # No need to do anything here, already handled by ajax:success handler
 
@@ -253,7 +253,7 @@ class window.SmartListing
     editable.remove()
 
     @container.trigger("smart_listing:remove", editable)
-  
+
   update_list: (content, data) =>
     @container.data(SmartListing.config.data_attribute("params"), $.extend(@container.data(SmartListing.config.data_attribute("params")), data[SmartListing.config.data_attribute("params")]))
     @container.data(SmartListing.config.data_attribute("max_count"), data[SmartListing.config.data_attribute("max_count")])
@@ -284,7 +284,7 @@ $.fn.smart_listing.observeField = (field, opts = {}) ->
      onEmpty: () ->
      onChange: () ->
    options = $.extend(options, opts)
- 
+
    keyChange = () ->
      if field.val().length > 0
        options.onFilled()
@@ -294,15 +294,15 @@ $.fn.smart_listing.observeField = (field, opts = {}) ->
      if field.val() == last_value && field.val().length != 0
        return
      lastValue = field.val()
- 
+
      options.onChange()
- 
+
    field.data(SmartListing.config.data_attribute("observed"), true)
- 
+
    field.bind "keydown", (e) ->
      if(key_timeout)
        clearTimeout(key_timeout)
- 
+
      regex = new RegExp("^[a-zA-Z0-9]+$")
      char = if !e.charCode then e.which else e.charCode
      str = String.fromCharCode(char)
@@ -348,17 +348,13 @@ $.fn.smart_listing.confirm = (elem, msg) ->
     elem.data("confirmed", false)
     true
 
-$.fn.smart_listing.onLoading = (content, loader, loading_indicator) ->
-  content.stop(true).fadeTo(500, 0.2)
-  loader.show()
+$.fn.smart_listing.onLoading = (loader, loading_indicator) ->
+  loader.addClass('active')
   loading_indicator.addClass('active')
-  loader.stop(true).fadeTo(500, 1)
 
-$.fn.smart_listing.onLoaded = (content, loader, loading_indicator) ->
-  content.stop(true).fadeTo(500, 1)
-  loader.stop(true).fadeTo 500, 0, () =>
-    loader.hide()
-    loading_indicator.removeClass('active')
+$.fn.smart_listing.onLoaded = (loader, loading_indicator) ->
+  loader.removeClass('active')
+  loading_indicator.removeClass('active')
 
 $.fn.smart_listing_controls = () ->
   reload = (controls) ->

--- a/app/assets/javascripts/smart_listing.coffee.erb
+++ b/app/assets/javascripts/smart_listing.coffee.erb
@@ -34,11 +34,11 @@ class window.SmartListing
     @confirmed = null
     @popovers = {}
 
-    @container.on "ajax:before", "#{SmartListing.config.class_name("item_actions")}, #{SmartListing.config.class_name("pagination_container")}", (e) =>
+    $(document).on "ajax:before", "#{SmartListing.config.class_name("item_actions")}, #{SmartListing.config.class_name("pagination_container")}", (e) =>
       @fadeLoading()
       console.log('ajax before')
 
-    @container.on "ajax:success", (e) =>
+    $(document).on "ajax:success", @container, (e) =>
       if $(e.target).is("#{SmartListing.config.class_name("item_actions")} #{SmartListing.config.selector("item_action_destroy")}")
         # handle HEAD OK response for deletion request
         editable = $(e.target).closest(SmartListing.config.class_name("editable"))

--- a/app/assets/javascripts/smart_listing.coffee.erb
+++ b/app/assets/javascripts/smart_listing.coffee.erb
@@ -28,7 +28,7 @@ class window.SmartListing
     @container = e
     @name = @container.attr("id")
     @loading = @container.find(SmartListing.config.class_name("loading"))
-    @loading_icon = @container.find(SmartListing.config.class_name("loading-icon"))
+    @loading_indicator = @container.find(SmartListing.config.class_name("loading_indicator"))
     @content = @container.find(SmartListing.config.class_name("content"))
     @status = $("#{SmartListing.config.class_name("status")} [data-#{SmartListing.config.data_attribute("main")}='#{@name}']")
     @confirmed = null
@@ -95,10 +95,10 @@ class window.SmartListing
       })
 
   fadeLoading: =>
-    $.fn.smart_listing.onLoading(@content, @loading, @loading_icon)
+    $.fn.smart_listing.onLoading(@content, @loading, @loading_indicator)
 
   fadeLoaded: =>
-    $.fn.smart_listing.onLoaded(@content, @loading, @loading_icon)
+    $.fn.smart_listing.onLoaded(@content, @loading, @loading_indicator)
   
   itemCount: =>
     parseInt(@container.data(SmartListing.config.data_attribute("item_count")))
@@ -348,17 +348,17 @@ $.fn.smart_listing.confirm = (elem, msg) ->
     elem.data("confirmed", false)
     true
 
-$.fn.smart_listing.onLoading = (content, loader, loading_icon) ->
+$.fn.smart_listing.onLoading = (content, loader, loading_indicator) ->
   content.stop(true).fadeTo(500, 0.2)
   loader.show()
-  loading_icon.show()
+  loading_indicator.show()
   loader.stop(true).fadeTo(500, 1)
 
-$.fn.smart_listing.onLoaded = (content, loader, loading_icon) ->
+$.fn.smart_listing.onLoaded = (content, loader, loading_indicator) ->
   content.stop(true).fadeTo(500, 1)
   loader.stop(true).fadeTo 500, 0, () =>
     loader.hide()
-    loading_icon.hide()
+    loading_indicator.hide()
 
 $.fn.smart_listing_controls = () ->
   reload = (controls) ->

--- a/app/assets/javascripts/smart_listing.coffee.erb
+++ b/app/assets/javascripts/smart_listing.coffee.erb
@@ -28,7 +28,7 @@ class window.SmartListing
     @container = e
     @name = @container.attr("id")
     @loading = @container.find(SmartListing.config.class_name("loading"))
-    @loading_indicator = @container.find(SmartListing.config.class_name("loading_indicator"))
+    @loading_indicator = $("#{SmartListing.config.class_name("loading_indicator")}")
     @content = @container.find(SmartListing.config.class_name("content"))
     @status = $("#{SmartListing.config.class_name("status")} [data-#{SmartListing.config.data_attribute("main")}='#{@name}']")
     @confirmed = null

--- a/app/assets/javascripts/smart_listing.coffee.erb
+++ b/app/assets/javascripts/smart_listing.coffee.erb
@@ -299,14 +299,16 @@ $.fn.smart_listing.observeField = (field, opts = {}) ->
    field.data(SmartListing.config.data_attribute("observed"), true)
  
    field.bind "keydown", (e) ->
-     console.log(e)
-     console.log(field)
      if(key_timeout)
        clearTimeout(key_timeout)
  
-     key_timeout = setTimeout(->
-       keyChange()
-     , 400)
+     regex = new RegExp("^[a-zA-Z0-9]+$")
+     char = if !e.charCode then e.which else e.charCode
+     str = String.fromCharCode(char)
+     if regex.test(str) || char == 8
+       key_timeout = setTimeout(->
+         keyChange()
+       , 400)
 
 $.fn.smart_listing.showPopover = (elem, body) ->
   elem.popover("destroy")

--- a/app/assets/javascripts/smart_listing.coffee.erb
+++ b/app/assets/javascripts/smart_listing.coffee.erb
@@ -382,17 +382,9 @@ $.fn.smart_listing_controls = () ->
       reload(controls)
       false
 
-    controls.find("select").change () ->
+    controls.find("input, select").change () ->
       unless $(this).data(SmartListing.config.data_attribute("observed")) # do not submit controls form when changed field is observed (observing submits form by itself)
         reload(controls)
-    
-    controls.find("input").keypress (e) ->
-      unless $(this).data(SmartListing.config.data_attribute("observed")) # do not submit controls form when changed field is observed (observing submits form by itself)
-        regex = new RegExp("^[a-zA-Z0-9]+$")
-        char = if !e.charCode then e.which else e.charCode
-        str = String.fromCharCode(char)
-        if regex.test(str) || char ==  8
-          reload(controls)
 
     $.fn.smart_listing_controls.filter(controls.find(SmartListing.config.class_name("filtering")))
 

--- a/app/assets/javascripts/smart_listing.coffee.erb
+++ b/app/assets/javascripts/smart_listing.coffee.erb
@@ -391,7 +391,7 @@ $.fn.smart_listing_controls = () ->
         regex = new RegExp("^[a-zA-Z0-9]+$")
         char = if !e.charCode then e.which else e.charCode
         str = String.fromCharCode(char)
-        if regex.test(str) || char ===  8
+        if regex.test(str) || char ==  8
           reload(controls)
 
     $.fn.smart_listing_controls.filter(controls.find(SmartListing.config.class_name("filtering")))

--- a/app/assets/javascripts/smart_listing.coffee.erb
+++ b/app/assets/javascripts/smart_listing.coffee.erb
@@ -389,7 +389,7 @@ $.fn.smart_listing_controls = () ->
     controls.find("input").keypress (e) ->
       unless $(this).data(SmartListing.config.data_attribute("observed")) # do not submit controls form when changed field is observed (observing submits form by itself)
         regex = new RegExp("^[a-zA-Z0-9]+$")
-        char = !e.charCode ? e.which : e.charCode
+        char = if !e.charCode then e.which else e.charCode
         str = String.fromCharCode(char)
         if regex.test(str) || char ===  8
           reload(controls)

--- a/app/assets/javascripts/smart_listing.coffee.erb
+++ b/app/assets/javascripts/smart_listing.coffee.erb
@@ -351,7 +351,6 @@ $.fn.smart_listing.confirm = (elem, msg) ->
 $.fn.smart_listing.onLoading = (content, loader, loading_indicator) ->
   content.stop(true).fadeTo(500, 0.2)
   loader.show()
-  console.log(loading_indicator)
   loading_indicator.addClass('active')
   loader.stop(true).fadeTo(500, 1)
 
@@ -401,7 +400,6 @@ $.fn.smart_listing_controls.filter = (filter) ->
   button = form.find(SmartListing.config.selector("filtering_button"))
   icon = form.find(SmartListing.config.selector("filtering_icon"))
   field = form.find(SmartListing.config.selector("filtering_input"))
-  console.log(field)
   loading_indicator = $("#{SmartListing.config.class_name("loading_indicator")}")
 
   $.fn.smart_listing.observeField(field,
@@ -409,17 +407,19 @@ $.fn.smart_listing_controls.filter = (filter) ->
       icon.removeClass(SmartListing.config.class("filtering_search"))
       icon.addClass(SmartListing.config.class("filtering_cancel"))
       button.removeClass(SmartListing.config.class("filtering_disabled"))
-      console.log('filled'+field)
     onEmpty: ->
       icon.addClass(SmartListing.config.class("filtering_search"))
       icon.removeClass(SmartListing.config.class("filtering_cancel"))
       button.addClass(SmartListing.config.class("filtering_disabled"))
-      console.log('empty'+field)
     onChange: ->
       loading_indicator.addClass('active')
-      console.log(form.serialize())
-      form.submit()
-      loading_indicator.removeClass('active')
+      $.ajax
+        type: form.attr('method')
+        url: form.attr('action')
+        data: form.serialize()
+        dataType: 'script'
+        success: (data, status, response)->
+          loading_indicator.removeClass('active')
   )
 
   button.click ->

--- a/app/assets/javascripts/smart_listing.coffee.erb
+++ b/app/assets/javascripts/smart_listing.coffee.erb
@@ -382,9 +382,17 @@ $.fn.smart_listing_controls = () ->
       reload(controls)
       false
 
-    controls.find("input, select").change () ->
+    controls.find("select").change () ->
       unless $(this).data(SmartListing.config.data_attribute("observed")) # do not submit controls form when changed field is observed (observing submits form by itself)
         reload(controls)
+    
+    controls.find("input").keypress (e) ->
+      unless $(this).data(SmartListing.config.data_attribute("observed")) # do not submit controls form when changed field is observed (observing submits form by itself)
+        regex = new RegExp("^[a-zA-Z0-9]+$")
+        char = !e.charCode ? e.which : e.charCode
+        str = String.fromCharCode(char)
+        if regex.test(str) || char ===  8
+          reload(controls)
 
     $.fn.smart_listing_controls.filter(controls.find(SmartListing.config.class_name("filtering")))
 

--- a/app/assets/javascripts/smart_listing.coffee.erb
+++ b/app/assets/javascripts/smart_listing.coffee.erb
@@ -412,14 +412,7 @@ $.fn.smart_listing_controls.filter = (filter) ->
       icon.removeClass(SmartListing.config.class("filtering_cancel"))
       button.addClass(SmartListing.config.class("filtering_disabled"))
     onChange: ->
-      loading_indicator.addClass('active')
-      $.ajax
-        type: form.attr('method')
-        url: form.attr('action')
-        data: form.serialize()
-        dataType: 'script'
-        success: (data, status, response)->
-          loading_indicator.removeClass('active')
+      form.submit()
   )
 
   button.click ->

--- a/app/assets/javascripts/smart_listing.coffee.erb
+++ b/app/assets/javascripts/smart_listing.coffee.erb
@@ -349,16 +349,12 @@ $.fn.smart_listing.confirm = (elem, msg) ->
     true
 
 $.fn.smart_listing.onLoading = (content, loader, loading_indicator) ->
-  content.stop(true).fadeTo(500, 0.2)
-  loader.show()
+  loader.addClass('active')
   loading_indicator.addClass('active')
-  loader.stop(true).fadeTo(500, 1)
 
 $.fn.smart_listing.onLoaded = (content, loader, loading_indicator) ->
-  content.stop(true).fadeTo(500, 1)
-  loader.stop(true).fadeTo 500, 0, () =>
-    loader.hide()
-    loading_indicator.removeClass('active')
+  loader.removeClass('active')
+  loading_indicator.removeClass('active')
 
 $.fn.smart_listing_controls = () ->
   reload = (controls) ->

--- a/app/assets/javascripts/smart_listing.coffee.erb
+++ b/app/assets/javascripts/smart_listing.coffee.erb
@@ -401,6 +401,7 @@ $.fn.smart_listing_controls.filter = (filter) ->
   button = form.find(SmartListing.config.selector("filtering_button"))
   icon = form.find(SmartListing.config.selector("filtering_icon"))
   field = form.find(SmartListing.config.selector("filtering_input"))
+  console.log(field)
   loading_indicator = $("#{SmartListing.config.class_name("loading_indicator")}")
 
   $.fn.smart_listing.observeField(field,
@@ -408,10 +409,12 @@ $.fn.smart_listing_controls.filter = (filter) ->
       icon.removeClass(SmartListing.config.class("filtering_search"))
       icon.addClass(SmartListing.config.class("filtering_cancel"))
       button.removeClass(SmartListing.config.class("filtering_disabled"))
+      console.log('filled'+field)
     onEmpty: ->
       icon.addClass(SmartListing.config.class("filtering_search"))
       icon.removeClass(SmartListing.config.class("filtering_cancel"))
       button.addClass(SmartListing.config.class("filtering_disabled"))
+      console.log('empty'+field)
     onChange: ->
       loading_indicator.addClass('active')
       console.log(form.serialize())

--- a/app/assets/javascripts/smart_listing.coffee.erb
+++ b/app/assets/javascripts/smart_listing.coffee.erb
@@ -28,7 +28,7 @@ class window.SmartListing
     @container = e
     @name = @container.attr("id")
     @loading = @container.find(SmartListing.config.class_name("loading"))
-    @loading_indicator = @container.find(SmartListing.config.class_name("loading-icon"))
+    @loading_indicator = @container.find(SmartListing.config.class_name("loading_indicator"))
     @content = @container.find(SmartListing.config.class_name("content"))
     @status = $("#{SmartListing.config.class_name("status")} [data-#{SmartListing.config.data_attribute("main")}='#{@name}']")
     @confirmed = null

--- a/app/assets/javascripts/smart_listing.coffee.erb
+++ b/app/assets/javascripts/smart_listing.coffee.erb
@@ -38,6 +38,7 @@ class window.SmartListing
       @fadeLoading()
 
     $(document).on "ajax:success", @container, (e) =>
+      @fadeLoaded()
       if $(e.target).is("#{SmartListing.config.class_name("item_actions")} #{SmartListing.config.selector("item_action_destroy")}")
         # handle HEAD OK response for deletion request
         editable = $(e.target).closest(SmartListing.config.class_name("editable"))
@@ -52,7 +53,6 @@ class window.SmartListing
         @changeItemCount(-1)
         @refresh()
 
-        @fadeLoaded()
         return false
 
     $(document).on "click", SmartListing.config.selector("edit_cancel"), (event) =>

--- a/app/assets/javascripts/smart_listing.coffee.erb
+++ b/app/assets/javascripts/smart_listing.coffee.erb
@@ -28,6 +28,7 @@ class window.SmartListing
     @container = e
     @name = @container.attr("id")
     @loading = @container.find(SmartListing.config.class_name("loading"))
+    @loading_icon = @container.find(SmartListing.config.class_name("loading-icon"))
     @content = @container.find(SmartListing.config.class_name("content"))
     @status = $("#{SmartListing.config.class_name("status")} [data-#{SmartListing.config.data_attribute("main")}='#{@name}']")
     @confirmed = null
@@ -94,10 +95,10 @@ class window.SmartListing
       })
 
   fadeLoading: =>
-    $.fn.smart_listing.onLoading(@content, @loading)
+    $.fn.smart_listing.onLoading(@content, @loading, @loading_icon)
 
   fadeLoaded: =>
-    $.fn.smart_listing.onLoaded(@content, @loading)
+    $.fn.smart_listing.onLoaded(@content, @loading, @loading_icon)
   
   itemCount: =>
     parseInt(@container.data(SmartListing.config.data_attribute("item_count")))
@@ -347,15 +348,17 @@ $.fn.smart_listing.confirm = (elem, msg) ->
     elem.data("confirmed", false)
     true
 
-$.fn.smart_listing.onLoading = (content, loader) ->
+$.fn.smart_listing.onLoading = (content, loader, loading_icon) ->
   content.stop(true).fadeTo(500, 0.2)
   loader.show()
+  loading_icon.show()
   loader.stop(true).fadeTo(500, 1)
 
-$.fn.smart_listing.onLoaded = (content, loader) ->
+$.fn.smart_listing.onLoaded = (content, loader, loading_icon) ->
   content.stop(true).fadeTo(500, 1)
   loader.stop(true).fadeTo 500, 0, () =>
     loader.hide()
+    loading_icon.hide()
 
 $.fn.smart_listing_controls = () ->
   reload = (controls) ->

--- a/app/assets/javascripts/smart_listing.coffee.erb
+++ b/app/assets/javascripts/smart_listing.coffee.erb
@@ -25,6 +25,7 @@ class window.SmartListing
 
 
   constructor: (e) ->
+    console.log(e)
     @container = e
     @name = @container.attr("id")
     @loading = @container.find(SmartListing.config.class_name("loading"))

--- a/app/assets/javascripts/smart_listing.coffee.erb
+++ b/app/assets/javascripts/smart_listing.coffee.erb
@@ -299,6 +299,8 @@ $.fn.smart_listing.observeField = (field, opts = {}) ->
    field.data(SmartListing.config.data_attribute("observed"), true)
  
    field.bind "keydown", (e) ->
+    console.log(e)
+    console.log(field)
      if(key_timeout)
        clearTimeout(key_timeout)
  

--- a/app/assets/javascripts/smart_listing.coffee.erb
+++ b/app/assets/javascripts/smart_listing.coffee.erb
@@ -401,6 +401,7 @@ $.fn.smart_listing_controls.filter = (filter) ->
   button = form.find(SmartListing.config.selector("filtering_button"))
   icon = form.find(SmartListing.config.selector("filtering_icon"))
   field = form.find(SmartListing.config.selector("filtering_input"))
+  loading_indicator = $("#{SmartListing.config.class_name("loading_indicator")}")
 
   $.fn.smart_listing.observeField(field,
     onFilled: ->
@@ -412,7 +413,10 @@ $.fn.smart_listing_controls.filter = (filter) ->
       icon.removeClass(SmartListing.config.class("filtering_cancel"))
       button.addClass(SmartListing.config.class("filtering_disabled"))
     onChange: ->
+      loading_indicator.addClass('active')
+      console.log(form.serialize())
       form.submit()
+      loading_indicator.removeClass('active')
   )
 
   button.click ->

--- a/app/assets/javascripts/smart_listing.coffee.erb
+++ b/app/assets/javascripts/smart_listing.coffee.erb
@@ -36,7 +36,6 @@ class window.SmartListing
 
     $(document).on "ajax:before", @container, (e) =>
       @fadeLoading()
-      console.log('ajax before')
 
     $(document).on "ajax:success", @container, (e) =>
       if $(e.target).is("#{SmartListing.config.class_name("item_actions")} #{SmartListing.config.selector("item_action_destroy")}")
@@ -54,10 +53,9 @@ class window.SmartListing
         @refresh()
 
         @fadeLoaded()
-        console.log('ajax success')
         return false
 
-    @container.on "click", SmartListing.config.selector("edit_cancel"), (event) =>
+    $(document).on "click", SmartListing.config.selector("edit_cancel"), (event) =>
       editable = $(event.currentTarget).closest(SmartListing.config.class_name("editable"))
       if(editable.length > 0)
         # Cancel edit
@@ -70,20 +68,20 @@ class window.SmartListing
       @setAutoshow(false)
       false
 
-    @container.on "click", "#{SmartListing.config.class_name("item_actions")} a[data-#{SmartListing.config.data_attribute("confirmation")}]", (event) =>
+    $(document).on "click", "#{SmartListing.config.class_name("item_actions")} a[data-#{SmartListing.config.data_attribute("confirmation")}]", (event) =>
       $.fn.smart_listing.confirm $(event.currentTarget), $(event.currentTarget).data(SmartListing.config.data_attribute("confirmation"))
 
-    @container.on "click", "#{SmartListing.config.class_name("item_actions")} a[data-#{SmartListing.config.data_attribute("popover")}]", (event) =>
+    $(document).on "click", "#{SmartListing.config.class_name("item_actions")} a[data-#{SmartListing.config.data_attribute("popover")}]", (event) =>
       name = $(event.currentTarget).data(SmartListing.config.data_attribute("popover"))
       if jQuery.isFunction(@popovers[name])
         @popovers[name]($(event.currentTarget))
         false
 
 
-    @container.on "click", "input[type=text]#{SmartListing.config.class_name("autoselect")}", (event) ->
+    $(document).on "click", "input[type=text]#{SmartListing.config.class_name("autoselect")}", (event) ->
       $(this).select()
 
-    @container.on "change", SmartListing.config.class_name("callback"), (event) =>
+    $(document).on "change", SmartListing.config.class_name("callback"), (event) =>
       checkbox = $(event.currentTarget)
       id = checkbox.closest(SmartListing.config.selector("row")).data(SmartListing.config.data_attribute("id"))
       data = {}
@@ -375,8 +373,6 @@ $.fn.smart_listing_controls = () ->
     smart_listing.params(prms)
 
     container.trigger("ajax:before")
-    console.log("ajax before triggered")
-    console.log(container)
     smart_listing.reload()
 
   $(this).each () ->

--- a/app/assets/javascripts/smart_listing.coffee.erb
+++ b/app/assets/javascripts/smart_listing.coffee.erb
@@ -34,11 +34,11 @@ class window.SmartListing
     @confirmed = null
     @popovers = {}
 
-    @container.on "ajax:before", "#{SmartListing.config.class_name("item_actions")}, #{SmartListing.config.class_name("pagination_container")}", (e) =>
+    $(document).on "ajax:before", @container, (e) =>
       @fadeLoading()
       console.log('ajax before')
 
-    @container.on "ajax:success", (e) =>
+    $(document).on "ajax:success", @container, (e) =>
       if $(e.target).is("#{SmartListing.config.class_name("item_actions")} #{SmartListing.config.selector("item_action_destroy")}")
         # handle HEAD OK response for deletion request
         editable = $(e.target).closest(SmartListing.config.class_name("editable"))

--- a/app/assets/javascripts/smart_listing.coffee.erb
+++ b/app/assets/javascripts/smart_listing.coffee.erb
@@ -400,7 +400,6 @@ $.fn.smart_listing_controls.filter = (filter) ->
   button = form.find(SmartListing.config.selector("filtering_button"))
   icon = form.find(SmartListing.config.selector("filtering_icon"))
   field = form.find(SmartListing.config.selector("filtering_input"))
-  loading_indicator = $("#{SmartListing.config.class_name("loading_indicator")}")
 
   $.fn.smart_listing.observeField(field,
     onFilled: ->

--- a/app/assets/javascripts/smart_listing.coffee.erb
+++ b/app/assets/javascripts/smart_listing.coffee.erb
@@ -25,7 +25,6 @@ class window.SmartListing
 
 
   constructor: (e) ->
-    console.log(e)
     @container = e
     @name = @container.attr("id")
     @loading = @container.find(SmartListing.config.class_name("loading"))

--- a/app/assets/javascripts/smart_listing.coffee.erb
+++ b/app/assets/javascripts/smart_listing.coffee.erb
@@ -351,6 +351,7 @@ $.fn.smart_listing.confirm = (elem, msg) ->
 $.fn.smart_listing.onLoading = (content, loader, loading_indicator) ->
   content.stop(true).fadeTo(500, 0.2)
   loader.show()
+  console.log(loading_indicator)
   loading_indicator.addClass('active')
   loader.stop(true).fadeTo(500, 1)
 

--- a/app/assets/javascripts/smart_listing.coffee.erb
+++ b/app/assets/javascripts/smart_listing.coffee.erb
@@ -36,6 +36,7 @@ class window.SmartListing
 
     @container.on "ajax:before", "#{SmartListing.config.class_name("item_actions")}, #{SmartListing.config.class_name("pagination_container")}", (e) =>
       @fadeLoading()
+      console.log('ajax before')
 
     @container.on "ajax:success", (e) =>
       if $(e.target).is("#{SmartListing.config.class_name("item_actions")} #{SmartListing.config.selector("item_action_destroy")}")
@@ -53,6 +54,7 @@ class window.SmartListing
         @refresh()
 
         @fadeLoaded()
+        console.log('ajax success')
         return false
 
     @container.on "click", SmartListing.config.selector("edit_cancel"), (event) =>

--- a/app/assets/javascripts/smart_listing.coffee.erb
+++ b/app/assets/javascripts/smart_listing.coffee.erb
@@ -34,11 +34,11 @@ class window.SmartListing
     @confirmed = null
     @popovers = {}
 
-    $(document).on "ajax:before", "#{SmartListing.config.class_name("item_actions")}, #{SmartListing.config.class_name("pagination_container")}", (e) =>
+    @container.on "ajax:before", "#{SmartListing.config.class_name("item_actions")}, #{SmartListing.config.class_name("pagination_container")}", (e) =>
       @fadeLoading()
       console.log('ajax before')
 
-    $(document).on "ajax:success", @container, (e) =>
+    @container.on "ajax:success", (e) =>
       if $(e.target).is("#{SmartListing.config.class_name("item_actions")} #{SmartListing.config.selector("item_action_destroy")}")
         # handle HEAD OK response for deletion request
         editable = $(e.target).closest(SmartListing.config.class_name("editable"))
@@ -375,6 +375,8 @@ $.fn.smart_listing_controls = () ->
     smart_listing.params(prms)
 
     container.trigger("ajax:before")
+    console.log("ajax before triggered")
+    console.log(container)
     smart_listing.reload()
 
   $(this).each () ->

--- a/app/assets/javascripts/smart_listing.coffee.erb
+++ b/app/assets/javascripts/smart_listing.coffee.erb
@@ -28,7 +28,7 @@ class window.SmartListing
     @container = e
     @name = @container.attr("id")
     @loading = @container.find(SmartListing.config.class_name("loading"))
-    @loading_indicator = $("loading_indicator")
+    @loading_indicator = @container.find(SmartListing.config.class_name("loading-icon"))
     @content = @container.find(SmartListing.config.class_name("content"))
     @status = $("#{SmartListing.config.class_name("status")} [data-#{SmartListing.config.data_attribute("main")}='#{@name}']")
     @confirmed = null
@@ -351,14 +351,14 @@ $.fn.smart_listing.confirm = (elem, msg) ->
 $.fn.smart_listing.onLoading = (content, loader, loading_indicator) ->
   content.stop(true).fadeTo(500, 0.2)
   loader.show()
-  loading_indicator.show()
+  loading_indicator.addClass('active')
   loader.stop(true).fadeTo(500, 1)
 
 $.fn.smart_listing.onLoaded = (content, loader, loading_indicator) ->
   content.stop(true).fadeTo(500, 1)
   loader.stop(true).fadeTo 500, 0, () =>
     loader.hide()
-    loading_indicator.hide()
+    loading_indicator.removeClass('active')
 
 $.fn.smart_listing_controls = () ->
   reload = (controls) ->

--- a/lib/generators/smart_listing/templates/initializer.rb
+++ b/lib/generators/smart_listing/templates/initializer.rb
@@ -20,6 +20,7 @@ SmartListing.configure do |config|
     #:editable              => "editable",
     #:content               => "content",
     #:loading               => "loading",
+    #:loading_indicator     => "loading-icon",
     #:status                => "smart-listing-status",
     #:item_actions          => "actions",
     #:new_item_placeholder  => "new-item-placeholder",

--- a/lib/generators/smart_listing/views_generator.rb
+++ b/lib/generators/smart_listing/views_generator.rb
@@ -17,6 +17,10 @@ BANNER
         Dir.glob(filename_pattern).map {|f| File.basename f}.each do |f|
           copy_file f, "app/views/smart_listing/#{f}"
         end
+        filename_pattern = File.join self.class.source_root, "*.js.erb"
+        Dir.glob(filename_pattern).map {|f| File.basename f}.each do |f|
+          copy_file f, "app/views/smart_listing/#{f}"
+        end
       end
 		end
 	end

--- a/lib/generators/smart_listing/views_generator.rb
+++ b/lib/generators/smart_listing/views_generator.rb
@@ -13,7 +13,7 @@ BANNER
 
       desc ''
       def copy_views
-      	FileUtils.cp_r self.class.source_root, "app/views/smart_listing/"
+      	FileUtils.cp_r self.class.source_root, "app/views/"
         # filename_pattern = File.join self.class.source_root, "**/*"
         #Dir.glob(filename_pattern).map {|f| File.basename f}.each do |f|
         #  copy_file f, "app/views/smart_listing/#{f}"

--- a/lib/generators/smart_listing/views_generator.rb
+++ b/lib/generators/smart_listing/views_generator.rb
@@ -13,10 +13,11 @@ BANNER
 
       desc ''
       def copy_views
-        filename_pattern = File.join self.class.source_root, "**/*"
-        Dir.glob(filename_pattern).map {|f| File.basename f}.each do |f|
-          copy_file f, "app/views/smart_listing/#{f}"
-        end
+      	FileUtils.cp_r self.class.source_root, "app/views/smart_listing/"
+        # filename_pattern = File.join self.class.source_root, "**/*"
+        #Dir.glob(filename_pattern).map {|f| File.basename f}.each do |f|
+        #  copy_file f, "app/views/smart_listing/#{f}"
+        #end
       end
 		end
 	end

--- a/lib/generators/smart_listing/views_generator.rb
+++ b/lib/generators/smart_listing/views_generator.rb
@@ -13,11 +13,10 @@ BANNER
 
       desc ''
       def copy_views
-      	FileUtils.cp_r self.class.source_root, "app/views/"
-        # filename_pattern = File.join self.class.source_root, "**/*"
-        #Dir.glob(filename_pattern).map {|f| File.basename f}.each do |f|
-        #  copy_file f, "app/views/smart_listing/#{f}"
-        #end
+        filename_pattern = File.join self.class.source_root, "*.html.erb"
+        Dir.glob(filename_pattern).map {|f| File.basename f}.each do |f|
+          copy_file f, "app/views/smart_listing/#{f}"
+        end
       end
 		end
 	end

--- a/lib/generators/smart_listing/views_generator.rb
+++ b/lib/generators/smart_listing/views_generator.rb
@@ -13,11 +13,7 @@ BANNER
 
       desc ''
       def copy_views
-        filename_pattern = File.join self.class.source_root, "*.html.erb"
-        Dir.glob(filename_pattern).map {|f| File.basename f}.each do |f|
-          copy_file f, "app/views/smart_listing/#{f}"
-        end
-        filename_pattern = File.join self.class.source_root, "*.js.erb"
+        filename_pattern = File.join self.class.source_root, "**/*/"
         Dir.glob(filename_pattern).map {|f| File.basename f}.each do |f|
           copy_file f, "app/views/smart_listing/#{f}"
         end

--- a/lib/generators/smart_listing/views_generator.rb
+++ b/lib/generators/smart_listing/views_generator.rb
@@ -13,7 +13,7 @@ BANNER
 
       desc ''
       def copy_views
-        filename_pattern = File.join self.class.source_root, "**/*/"
+        filename_pattern = File.join self.class.source_root, "**/*"
         Dir.glob(filename_pattern).map {|f| File.basename f}.each do |f|
           copy_file f, "app/views/smart_listing/#{f}"
         end

--- a/lib/smart_listing/config.rb
+++ b/lib/smart_listing/config.rb
@@ -38,6 +38,7 @@ module SmartListing
           :editable => "editable",
           :content => "content",
           :loading => "loading",
+          :loading_indicator => "loading-icon",
           :status => "smart-listing-status",
           :item_actions => "actions",
           :new_item_placeholder => "new-item-placeholder",

--- a/lib/smart_listing/version.rb
+++ b/lib/smart_listing/version.rb
@@ -1,3 +1,3 @@
 module SmartListing
-  VERSION = "1.1.2"
+  VERSION = '1.1.3'
 end


### PR DESCRIPTION
Turbolinks requires event listeners to be attached to the document, and then scoped to the container. Otherwise, ajax:before and ajax:success events on the container don't get listened.

Also added a fix for only firing ajax on inputs when typing - not on focus or tab switching.

Config also now has loading indicator option.