### PR TITLE
Rails 5 support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     smart_listing (1.1.2)
       coffee-rails
       jquery-rails
-      kaminari (~> 0.16.1)
+      kaminari (~> 0.16)
       rails (>= 3.2)
 
 GEM
@@ -66,7 +66,7 @@ GEM
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
     json (1.8.1)
-    kaminari (0.16.1)
+    kaminari (0.17.0)
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
     mail (2.6.3)

--- a/app/helpers/smart_listing/helper.rb
+++ b/app/helpers/smart_listing/helper.rb
@@ -180,7 +180,7 @@ module SmartListing
       private
 
       def sanitize_params params
-        params.merge(UNSAFE_PARAMS)
+        params.permit!.merge(UNSAFE_PARAMS)
       end
 
       def default_locals

--- a/smart_listing.gemspec
+++ b/smart_listing.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "rails", ">=3.2"
   s.add_dependency "coffee-rails"
-  s.add_dependency "kaminari", "~> 0.16.1"
+  s.add_dependency "kaminari", "~> 0.16"
   s.add_dependency "jquery-rails"
 
   s.add_development_dependency "bootstrap-sass"


### PR DESCRIPTION
Rails 5 introduced additional parameter checking so update to kaminari and parameters permit was necessary to have smart_listing working.

Please note that I don't know smart_listing internals enough so I'm not sure that the blind parameter permit as done in this pull request is secure or not.

Test by using this in your Gemfile:
```
gem 'smart_listing', :git => "git://github.com/akostadinov/smart_listing.git", :branch => 'master'
```

fixes #92 

P.S. also not tested if compatibility with older Rails is retained. I assume rails 4 would be covered but don't know about older versions.