### PR TITLE
clicking `cancel` on editable row after failed update

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,8 +215,14 @@ Partial name supplied to `smart_listing_item` (`users/form`) references `@user` 
 And one last thing are `create` and `update` controller actions JS view:
 
 ```ruby
+<%# create.js.erb %>
 <%= smart_listing_item :users, :create, @user, @user.persisted? ? "users/user" : "users/form" %>
-<%= smart_listing_item :users, :update, @user, @user.valid? ? "users/user" : "users/form" %>
+```
+```ruby
+<%# update.js.erb %>
+<% if @user.valid? %>
+  <%= smart_listing_item :users, :update, @user, "users/user" %>
+<% end %>
 ```
 
 ### Controls (filtering)


### PR DESCRIPTION
Clicking `cancel` on editable row after failed update doesn't hide the form to show row content. Clicking `cancel` with the `update.js.erb` from documentation example works only if no failed attempts to update row were ever performed.

I'm not sure if this is a bug in smart listing or just documentation is wrong. I have updated documentation as to how to write the update code to avoid it. Please let me know if this is actually an indication of another bug to be fixed.

The problem with original example code is that when you try to save a row unsuccessfully, then clicking `cancel` has no effect anymore. When we avoid rendering anything on error, clicking `close` always hides form and shows original row content (regardless of how hard user tried to enter invalid new values).