### PR TITLE
Fix test suite

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,4 @@
+# Running Specs
+
+To run the specs you must `rake app:db:migrate` from the project root
+before running `rspec spec` or `rake app:spec`.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # SmartListing
 
+[![CircleCI](https://circleci.com/gh/Sology/smart_listing.svg?style=svg)](https://circleci.com/gh/Sology/smart_listing)
+
 SmartListing helps creating AJAX-enabled lists of ActiveRecord collections or arrays with pagination, filtering, sorting and in-place editing.
 
 [See it in action](http://showcase.sology.eu/smart_listing)

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+dependencies:
+  post:
+    - bundle exec rake app:db:migrate

--- a/spec/dummy/db/migrate/20141028214800_user.rb
+++ b/spec/dummy/db/migrate/20141028214800_user.rb
@@ -1,4 +1,8 @@
 class User < ActiveRecord::Migration
   def change
+    create_table "users", force: true do |t|
+      t.string "name"
+      t.string "email"
+    end
   end
 end


### PR DESCRIPTION
It looks like there was a migration in the dummy app that was completely empty, breaking the ability to run the specs. I've fixed that, as well as documented in a `CONTRIBUTING.md` how to run the specs. I've also added in a circle.yml file so CircleCI can run the suite (for free) and a status badge in the README to show whether the build passes. In order to merge this and have that status badge work, a maintainer with write access to this repo will need to mash a button on CircleCI to have them build it.

All of the above said, it looks like there are currently 3 specs broken. Hopefully merging this will encourage someone (maybe even me) to submit fixes for them, and will head off future breakage.

Hope this helps,

Brandon
