### PR TITLE
Allow smart_listings to render outside of controllers

### DIFF
--- a/app/helpers/smart_listing/helper.rb
+++ b/app/helpers/smart_listing/helper.rb
@@ -11,6 +11,7 @@ module SmartListing
         name = (args[0] || options[:name] || controller_name).to_sym
         collection = args[1] || options[:collection] || smart_listing_collection
 
+        view_context = self.respond_to?(:controller) ? controller.view_context : self.view_context
         options = {:config_profile => view_context.smart_listing_config_profile}.merge(options)
 
         list = SmartListing::Base.new(name, collection, options)


### PR DESCRIPTION
In Rails 5 it is possible to render a view outside of a controller action. This simple change allows the smart_listing to be rendered in those other contexts. In a nutshell, if you're not in a controller, you need to call `controller.view_context` to retrieve the `view_context`.

You still need to call `smart_listing_create` just before where ever you intend to render your smart_listing view but it is at least now possible to do so. The Javascript works exactly as expected and hits the controller action to update the view.

Here's more on rendering views outside of controller actions in Rails 5: https://evilmartians.com/chronicles/new-feature-in-rails-5-render-views-outside-of-actions
