### PR TITLE
use id.to_json so integers and uuids will both work

### DIFF
--- a/app/views/smart_listing/item/_create.js.erb
+++ b/app/views/smart_listing/item/_create.js.erb
@@ -1,3 +1,3 @@
 var smart_listing = $('#<%= name %>').smart_listing();
 smart_listing.setAutoshow(false);
-smart_listing.create(<%= id || 0 %>, <%= object.persisted? %>, "<%= escape_javascript(render(:partial => part, :locals => {object_key => object})) %>");
+smart_listing.create(<%= (id || 0).to_json %>, <%= object.persisted? %>, "<%= escape_javascript(render(:partial => part, :locals => {object_key => object})) %>");

--- a/app/views/smart_listing/item/_create.js.erb
+++ b/app/views/smart_listing/item/_create.js.erb
@@ -1,3 +1,3 @@
 var smart_listing = $('#<%= name %>').smart_listing();
 smart_listing.setAutoshow(false);
-smart_listing.create(<%= (id || 0).to_json %>, <%= object.persisted? %>, "<%= escape_javascript(render(:partial => part, :locals => {object_key => object})) %>");
+smart_listing.create(<%= escape_javascript((id || 0).to_json) %>, <%= object.persisted? %>, "<%= escape_javascript(render(:partial => part, :locals => {object_key => object})) %>");

--- a/app/views/smart_listing/item/_create_continue.js.erb
+++ b/app/views/smart_listing/item/_create_continue.js.erb
@@ -1,6 +1,6 @@
 var smart_listing = $('#<%= name %>').smart_listing();
 smart_listing.setAutoshow(true);
-smart_listing.create(<%= (id || 0).to_json %>, <%= object.persisted? %>, "<%= escape_javascript(render(:partial => part, :locals => {object_key => object})) %>");
+smart_listing.create(<%= escape_javascript((id || 0).to_json) %>, <%= object.persisted? %>, "<%= escape_javascript(render(:partial => part, :locals => {object_key => object})) %>");
 <% if object.persisted? %>
   smart_listing.new_item("<%= escape_javascript(render(:partial => new.last, :locals => {object_key => new.first})) %>");
 <% end %>

--- a/app/views/smart_listing/item/_create_continue.js.erb
+++ b/app/views/smart_listing/item/_create_continue.js.erb
@@ -1,6 +1,6 @@
 var smart_listing = $('#<%= name %>').smart_listing();
 smart_listing.setAutoshow(true);
-smart_listing.create(<%= id || 0 %>, <%= object.persisted? %>, "<%= escape_javascript(render(:partial => part, :locals => {object_key => object})) %>");
+smart_listing.create(<%= (id || 0).to_json %>, <%= object.persisted? %>, "<%= escape_javascript(render(:partial => part, :locals => {object_key => object})) %>");
 <% if object.persisted? %>
   smart_listing.new_item("<%= escape_javascript(render(:partial => new.last, :locals => {object_key => new.first})) %>");
 <% end %>

--- a/app/views/smart_listing/item/_destroy.js.erb
+++ b/app/views/smart_listing/item/_destroy.js.erb
@@ -1,2 +1,2 @@
 var smart_listing = $('#<%= name.to_s %>').smart_listing();
-smart_listing.destroy(<%= id.to_json %>, <%= object.destroyed? %>);
+smart_listing.destroy(<%= escape_javascript(id.to_json) %>, <%= object.destroyed? %>);

--- a/app/views/smart_listing/item/_destroy.js.erb
+++ b/app/views/smart_listing/item/_destroy.js.erb
@@ -1,2 +1,2 @@
 var smart_listing = $('#<%= name.to_s %>').smart_listing();
-smart_listing.destroy(<%= id %>, <%= object.destroyed? %>);
+smart_listing.destroy(<%= id.to_json %>, <%= object.destroyed? %>);

--- a/app/views/smart_listing/item/_edit.js.erb
+++ b/app/views/smart_listing/item/_edit.js.erb
@@ -1,2 +1,2 @@
 var smart_listing = $('#<%= name %>').smart_listing();
-smart_listing.edit(<%= id %>, "<%= escape_javascript(render(:partial => part, :locals => {object_key => object})) %>");
+smart_listing.edit(<%= id.to_json %>, "<%= escape_javascript(render(:partial => part, :locals => {object_key => object})) %>");

--- a/app/views/smart_listing/item/_edit.js.erb
+++ b/app/views/smart_listing/item/_edit.js.erb
@@ -1,2 +1,2 @@
 var smart_listing = $('#<%= name %>').smart_listing();
-smart_listing.edit(<%= id.to_json %>, "<%= escape_javascript(render(:partial => part, :locals => {object_key => object})) %>");
+smart_listing.edit(<%= escape_javascript(id.to_json) %>, "<%= escape_javascript(render(:partial => part, :locals => {object_key => object})) %>");

--- a/app/views/smart_listing/item/_remove.js.erb
+++ b/app/views/smart_listing/item/_remove.js.erb
@@ -1,2 +1,2 @@
 var smart_listing = $('#<%= name %>').smart_listing();
-smart_listing.remove(<%= id.to_json %>);
+smart_listing.remove(<%= escape_javascript(id.to_json) %>);

--- a/app/views/smart_listing/item/_remove.js.erb
+++ b/app/views/smart_listing/item/_remove.js.erb
@@ -1,2 +1,2 @@
 var smart_listing = $('#<%= name %>').smart_listing();
-smart_listing.remove(<%= id %>);
+smart_listing.remove(<%= id.to_json %>);

--- a/app/views/smart_listing/item/_update.js.erb
+++ b/app/views/smart_listing/item/_update.js.erb
@@ -1,2 +1,2 @@
 var smart_listing = $('#<%= name %>').smart_listing();
-smart_listing.update(<%= id %>, <%= valid.nil? ? object.valid? : valid %>, "<%= escape_javascript(render(:partial => part, :locals => {object_key => object})) %>");
+smart_listing.update(<%= id.to_json %>, <%= valid.nil? ? object.valid? : valid %>, "<%= escape_javascript(render(:partial => part, :locals => {object_key => object})) %>");

--- a/app/views/smart_listing/item/_update.js.erb
+++ b/app/views/smart_listing/item/_update.js.erb
@@ -1,2 +1,2 @@
 var smart_listing = $('#<%= name %>').smart_listing();
-smart_listing.update(<%= id.to_json %>, <%= valid.nil? ? object.valid? : valid %>, "<%= escape_javascript(render(:partial => part, :locals => {object_key => object})) %>");
+smart_listing.update(<%= escape_javascript(id.to_json) %>, <%= valid.nil? ? object.valid? : valid %>, "<%= escape_javascript(render(:partial => part, :locals => {object_key => object})) %>");


### PR DESCRIPTION
Using uuid, we have ids such as: ```d8d0517d-b146-4a5c-ae82-baa94d463dd5```

These cannot be used raw as integers can be used in javascript:

````
smart_listing.edit(d8d0517d-b146-4a5c-ae82-baa94d463dd5, "<td colspan=\'3\'>\n<form class=\"form-horizontal\" id=\"edit_result_d8d0517d-b146-4a5c-ae82-baa94d463dd5\" action=\"/results/d8d0517d-b146-4a5c-ae82-baa94d463dd5\" accept-charset=\"UTF-8\" data-remote=\"true\" method=\"post\"><input name=\"utf8\" type=\"hidden\" value=\"&#x2713;\" /><input type=\"hidden\" name=\"_method\" value=\"patch\" /><div class=\'field\'>\n<label for=\"result_name\">Name<\/label>\n<input type=\"text\" value=\"test\" name=\"result[name]\" id=\"result_name\" />\n<\/div>\n<div class=\'field\'>\n<label for=\"result_description\">Description<\/label>\n<textarea name=\"result[description]\" id=\"result_description\">\n<\/textarea>\n<\/div>\n<div class=\'actions\'>\n<input type=\"submit\" name=\"commit\" value=\"Save\" data-disable-with=\"Save\" />\n<button class=\'btn btn-link cancel\'>Cancel<\/button>\n<\/div>\n<\/form>\n<\/td>\n");
````

Instead, using ```id.to_json``` will wrap uuids (which are strings) inside of quotes, but will leave integers raw as before.