### PR TITLE
Fix popover in bootstrap 4

### DIFF
--- a/app/assets/javascripts/smart_listing.coffee.erb
+++ b/app/assets/javascripts/smart_listing.coffee.erb
@@ -24,6 +24,9 @@ class window.SmartListing
     @element_template: (name)->
       @options["constants"]["element_templates"][name]
 
+    @bootstrap_commands: (name)->
+      @options["constants"]["bootstrap_commands"][name]
+
   @config: Config
 
 
@@ -319,8 +322,8 @@ $.fn.smart_listing.observeField = (field, opts = {}) ->
      , 400)
 
 $.fn.smart_listing.showPopover = (elem, body) ->
-  elem.popover("destroy")
-  elem.popover(content: body, html: true, trigger: "manual", title: null)
+  elem.popover(SmartListing.config.bootstrap_commands("popover_destroy"))
+  elem.popover(content: body, html: true, trigger: "manual")
   elem.popover("show")
 
 $.fn.smart_listing.showConfirmation = (confirmation_elem, msg, confirm_callback) ->
@@ -333,12 +336,12 @@ $.fn.smart_listing.showConfirmation = (confirmation_elem, msg, confirm_callback)
         editable = $(event.currentTarget).closest(SmartListing.config.class_name("editable"))
         confirm_callback(confirmation_elem)
         $(confirmation_elem).click()
-        $(confirmation_elem).popover("destroy")
+        $(confirmation_elem).popover(SmartListing.config.bootstrap_commands("popover_destroy"))
       )
       .append(" ")
       .append($("<button/>").html("No").addClass("btn btn-small").click (event) =>
         editable = $(event.currentTarget).closest(SmartListing.config.class_name("editable"))
-        $(confirmation_elem).popover("destroy")
+        $(confirmation_elem).popover(SmartListing.config.bootstrap_commands("popover_destroy"))
       )
     )
 

--- a/app/views/smart_listing/item/_create.js.erb
+++ b/app/views/smart_listing/item/_create.js.erb
@@ -1,3 +1,3 @@
 var smart_listing = $('#<%= name %>').smart_listing();
 smart_listing.setAutoshow(false);
-smart_listing.create(<%= id || 0 %>, <%= object.persisted? %>, "<%= escape_javascript(render(:partial => part, :locals => {object_key => object})) %>");
+smart_listing.create(<%= (id || 0).to_json.html_safe %>, <%= object.persisted? %>, "<%= escape_javascript(render(:partial => part, :locals => {object_key => object})) %>");

--- a/app/views/smart_listing/item/_create_continue.js.erb
+++ b/app/views/smart_listing/item/_create_continue.js.erb
@@ -1,6 +1,6 @@
 var smart_listing = $('#<%= name %>').smart_listing();
 smart_listing.setAutoshow(true);
-smart_listing.create(<%= id || 0 %>, <%= object.persisted? %>, "<%= escape_javascript(render(:partial => part, :locals => {object_key => object})) %>");
+smart_listing.create(<%= (id || 0).to_json.html_safe %>, <%= object.persisted? %>, "<%= escape_javascript(render(:partial => part, :locals => {object_key => object})) %>");
 <% if object.persisted? %>
   smart_listing.new_item("<%= escape_javascript(render(:partial => new.last, :locals => {object_key => new.first})) %>");
 <% end %>

--- a/app/views/smart_listing/item/_destroy.js.erb
+++ b/app/views/smart_listing/item/_destroy.js.erb
@@ -1,2 +1,2 @@
 var smart_listing = $('#<%= name.to_s %>').smart_listing();
-smart_listing.destroy(<%= id %>, <%= object.destroyed? %>);
+smart_listing.destroy(<%= id.to_json.html_safe %>, <%= object.destroyed? %>);

--- a/app/views/smart_listing/item/_edit.js.erb
+++ b/app/views/smart_listing/item/_edit.js.erb
@@ -1,2 +1,2 @@
 var smart_listing = $('#<%= name %>').smart_listing();
-smart_listing.edit(<%= id %>, "<%= escape_javascript(render(:partial => part, :locals => {object_key => object})) %>");
+smart_listing.edit(<%= id.to_json.html_safe %>, "<%= escape_javascript(render(:partial => part, :locals => {object_key => object})) %>");

--- a/app/views/smart_listing/item/_remove.js.erb
+++ b/app/views/smart_listing/item/_remove.js.erb
@@ -1,2 +1,2 @@
 var smart_listing = $('#<%= name %>').smart_listing();
-smart_listing.remove(<%= id %>);
+smart_listing.remove(<%= id.to_json.html_safe %>);

--- a/app/views/smart_listing/item/_update.js.erb
+++ b/app/views/smart_listing/item/_update.js.erb
@@ -1,2 +1,2 @@
 var smart_listing = $('#<%= name %>').smart_listing();
-smart_listing.update(<%= id %>, <%= valid.nil? ? object.valid? : valid %>, "<%= escape_javascript(render(:partial => part, :locals => {object_key => object})) %>");
+smart_listing.update(<%= id.to_json.html_safe %>, <%= valid.nil? ? object.valid? : valid %>, "<%= escape_javascript(render(:partial => part, :locals => {object_key => object})) %>");

--- a/lib/generators/smart_listing/templates/initializer.rb
+++ b/lib/generators/smart_listing/templates/initializer.rb
@@ -85,4 +85,8 @@ SmartListing.configure do |config|
   config.constants :element_templates, {
     #:row => "<tr />",
   }
+
+  config.constants :bootstrap_commands, {
+    #:popover_destroy       => "destroy", # Bootstrap 4 requries dipsose instead of destroy
+  }
 end


### PR DESCRIPTION
Changes to allow using bootstrap 4 (admittedly, alpha).
- [popover command uses dispose instead of destroy](https://v4-alpha.getbootstrap.com/components/popovers/#methods) Use a config value to allow overriding this command.
- Title: null is no longer allowed, triggers a type error. Use default value: ''

Note: I took this branch off of the ```allow_uuid``` branch because I need both. You could cherry-pick these commits if you prefer.