### PR TITLE
Fix Kaminari #num_pages deprecation warning

### DIFF
--- a/lib/smart_listing.rb
+++ b/lib/smart_listing.rb
@@ -94,7 +94,7 @@ module SmartListing
         if @options[:paginate] && @per_page > 0
           @collection = ::Kaminari.paginate_array(@collection).page(@page).per(@per_page)
           if @collection.length == 0
-            @collection = @collection.page(@collection.num_pages)
+            @collection = @collection.page(@collection.total_pages)
           end
         end
       else


### PR DESCRIPTION
Fixes the following warning when running under Kaminari 0.17.0:

```
DEPRECATION WARNING: num_pages is deprecated and will be removed in Kaminari 1.0.
Please use total_pages instead.
```

This change should work with Kaminari all the way back to 0.14.0, which was released in 2012.