### PR TITLE
Add support for Turbolinks 5

### DIFF
--- a/app/assets/javascripts/smart_listing.coffee.erb
+++ b/app/assets/javascripts/smart_listing.coffee.erb
@@ -438,4 +438,4 @@ ready = ->
   $(SmartListing.config.class_name("controls")).smart_listing_controls()
 
 $(document).ready ready
-$(document).on "page:load", ready
+$(document).on "page:load turbolinks:load", ready


### PR DESCRIPTION
With Turbolinks 5 `page:load` is renamed to `turbolinks:ready`. See https://github.com/turbolinks/turbolinks#running-javascript-when-a-page-loads for example.