### PR TITLE
Use #empty? for AC::Params (Rails 5.1 compatibility)

### DIFF
--- a/lib/smart_listing.rb
+++ b/lib/smart_listing.rb
@@ -69,7 +69,7 @@ module SmartListing
 
       if @options[:array]
         if @sort && !@sort.empty? # when array we sort only by first attribute
-          i = sort_keys.index{|x| x[0] == @sort.first[0]}
+          i = sort_keys.index{|x| x[0] == @sort.to_h.first[0]}
           @collection = @collection.sort do |x, y|
             xval = x
             yval = y
@@ -83,7 +83,7 @@ module SmartListing
             if xval.nil? || yval.nil?
               xval.nil? ? 1 : -1
             else
-              if @sort.first[1] == "asc"
+              if @sort.to_h.first[1] == "asc"
                 (xval <=> yval) || (xval && !yval ? 1 : -1)
               else
                 (yval <=> xval) || (yval && !xval ? 1 : -1)

--- a/lib/smart_listing.rb
+++ b/lib/smart_listing.rb
@@ -68,7 +68,7 @@ module SmartListing
       end
 
       if @options[:array]
-        if @sort && @sort.any? # when array we sort only by first attribute
+        if @sort && !@sort.empty? # when array we sort only by first attribute
           i = sort_keys.index{|x| x[0] == @sort.first[0]}
           @collection = @collection.sort do |x, y|
             xval = x
@@ -100,7 +100,7 @@ module SmartListing
       else
         # let's sort by all attributes
         #
-        @collection = @collection.order(sort_keys.collect{|s| "#{s[1]} #{@sort[s[0]]}" if @sort[s[0]]}.compact) if @sort && @sort.any?
+        @collection = @collection.order(sort_keys.collect{|s| "#{s[1]} #{@sort[s[0]]}" if @sort[s[0]]}.compact) if @sort && !@sort.empty?
 
         if @options[:paginate] && @per_page > 0
           @collection = @collection.page(@page).per(@per_page)


### PR DESCRIPTION
[ActionController::Params does not inherit from HashWithIndifferentAccess anymore](http://edgeguides.rubyonrails.org/upgrading_ruby_on_rails.html#actioncontroller-parameters-no-longer-inherits-from-hashwithindifferentaccess)
This uses !empty? instead of any?
It also casts to a hash before calling `#first` on params
Fixes #121 