### PR TITLE
fix 'sanitize_params' method

### DIFF
--- a/app/helpers/smart_listing/helper.rb
+++ b/app/helpers/smart_listing/helper.rb
@@ -181,7 +181,7 @@ module SmartListing
       private
 
       def sanitize_params params
-        params = params.permit! if params.respond_to?(:permit!)
+        params = params.permit("#{@smart_listing.name}_smart_listing": @smart_listing.options[:param_names].values)
         params.merge(UNSAFE_PARAMS)
       end
 


### PR DESCRIPTION
This changes sanitize_method edited in this commit:
https://github.com/Sology/smart_listing/commit/e499361b31441496bc562af4c6ff62662fce3b7b
