### PR TITLE
replace deprecated .any? with .present?

### DIFF
--- a/app/helpers/smart_listing/helper.rb
+++ b/app/helpers/smart_listing/helper.rb
@@ -318,7 +318,7 @@ module SmartListing
       smart_listing = @smart_listings[name]
 
       # don't update list if params are missing (prevents interfering with other lists)
-      if params.keys.select{|k| k.include?("smart_listing")}.any? && !params[smart_listing.base_param]
+      if params.keys.select{|k| k.include?("smart_listing")}.present? && !params[smart_listing.base_param]
         return unless options[:force]
       end
 


### PR DESCRIPTION
The .any method is deprecated in rails 5.1.
As per the suggestions of this [Stack Overflow post](https://stackoverflow.com/a/39729069/7578279), I changed it to .present?

> DEPRECATION WARNING: Method any? is deprecated and will be removed in Rails 5.1, as ActionController::Parameters no longer inherits from hash. Using this deprecated behavior exposes potential security problems. If you continue to use this method you may be creating a security vulnerability in your app that can be exploited. Instead, consider using one of these documented methods which are not deprecated: http://api.rubyonrails.org/v5.0.0.rc1/classes/ActionController/Parameters.html

Have not personally tested.