### PR TITLE
Remove duplicated href key from config template

### DIFF
--- a/lib/generators/smart_listing/templates/initializer.rb
+++ b/lib/generators/smart_listing/templates/initializer.rb
@@ -65,7 +65,6 @@ SmartListing.configure do |config|
     #:inline_edit_backup    => "smart-listing-edit-backup",
     #:params                => "params",
     #:observed              => "observed",
-    #:href                  => "href",
     #:autoshow              => "autoshow",
     #:popover               => "slpopover",
   }


### PR DESCRIPTION
Hi there! Just started trying to use your gem, encountered a warning, now proposing the fix :)

Let me know if I need to do anything before your merge it.
Cheers!