### PR TITLE
Make 'NULLS FIRST/LAST' sortings available

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,16 @@ Implicit mode is convenient with simple data sets. In case you want to sort by j
 
 Note that `:sort_attributes` are array which of course means, that order of attributes matters.
 
-There's also a possibility to specify available sort directions using `:sort_dirs` option which is by default `[nil, "asc", "desc"]`.
+There is a possibility to specify available sort directions using `:sort_dirs` option which is by default `[nil, "asc", "desc"]`.
+So if you need, for example, order your data by `NULLS LAST` , you may pass it simply like that:
+
+```haml
+  ...
+    %th= smart_listing.sortable "User name", :name, { sort_dirs: ['asc', 'desc NULLS LAST']}
+    %th= smart_listing.sortable "Email", :email, { sort_dirs: [nil, 'ASC NULLS FIRST', 'desc']}
+  ...
+```
+**Be careful:** *`NULLS FIRST/LAST` may be not supported by your database (i.e. SQLite, Oracle < 8, some MySQL versions). However, you may use `COALESCE` directly in SQL as the most universal method in such cases.*
 
 ### List item management and in-place editing
 

--- a/lib/smart_listing.rb
+++ b/lib/smart_listing.rb
@@ -201,21 +201,32 @@ module SmartListing
 
       if @options[:sort_attributes] == :implicit
         sort = sort_params.dup if sort_params.present?
-      elsif @options[:sort_attributes]
-        @options[:sort_attributes].each do |a|
-          k, v = a
-          if sort_params && sort_params[k.to_s]
-            dir = ["asc", "desc", ""].delete(sort_params[k.to_s])
+      elsif @options[:sort_attributes] && sort_params.present?
+        @options[:sort_attributes].each do |attribute|
+          direction = attribute.first.nil? ? nil : sort_params[attribute.first.to_s]
 
-            if dir
-              sort ||= {}
-              sort[k] = dir
-            end
-          end
+          next if nil_or_not_a_safe_sort_direction?(direction)
+
+          sort ||= {}
+          sort[attribute.first] = direction
         end
       end
 
       sort
+    end
+
+    SAFE_SORT_DIRECTIONS = [
+      'asc',
+      'desc',
+      'asc nulls first',
+      'desc nulls first',
+      'asc nulls last',
+      'desc nulls last',
+      ''
+    ].freeze
+
+    def nil_or_not_a_safe_sort_direction?(direction)
+      direction.nil? || !SAFE_SORT_DIRECTIONS.include?(direction.downcase)
     end
   end
 end


### PR DESCRIPTION
There is no way to use `NULLS LAST` and `NULLS FIRST` sortings, except not safe `:implicit` setting, suggested to add these as safe sorting directions. Tiny refactoring included.